### PR TITLE
Correcting Answer ID in Dump Eval and Removing ANN in Environment Step

### DIFF
--- a/mlm_training.py
+++ b/mlm_training.py
@@ -375,7 +375,6 @@ def evaluate_training(
     answer_tokenizer: PreTrainedTokenizer,
     wandb_on: bool,
     iteration: int,
-    answer_id: List[int] = None,
 ):
     """
     Evaluates the performance of the navigation agent and language model on the development set.
@@ -504,6 +503,8 @@ def evaluate_training(
 
             # eval_extras has variables that we need
             just_dump_it_here = "./logs/evaluation_dumps.log"
+
+            answer_id = mini_batch["Answer-Entity"].tolist()
 
             answer_kge_tensor = get_embeddings_from_indices(
                 env.knowledge_graph.entity_embedding,
@@ -738,7 +739,6 @@ def train_multihopkg(
                     answer_tokenizer,
                     wandb_on,
                     iteration = epoch_id * (len(train_data) // batch_size // mbatches_b4_eval) + (batch_count // mbatches_b4_eval),
-                    answer_id=mini_batch["Answer-Entity"].tolist(),  # Extract answer_id from mini_batch
                 )
 
             ########################################

--- a/mlm_training.py
+++ b/mlm_training.py
@@ -968,7 +968,7 @@ def rollout(
         relevant_ent = relevant_entities
     )
 
-    cur_position, cur_state = observations.position, observations.state
+    cur_state = observations.state
     # Should be of shape (batch_size, 1, hidden_dim)
 
     # pn.initialize_path(kg) # TOREM: Unecessasry to ask pn to form it for us.
@@ -984,8 +984,6 @@ def rollout(
         # Ah ssampled_actions are the ones that have to go against the knowlde garph.
 
         states = observations.state
-        visited_embeddings = observations.position.clone() if isinstance(observations.position, torch.Tensor) else torch.tensor(observations.position).clone()
-        position_ids = observations.position_id.clone() if isinstance(observations.position_id, torch.Tensor) else torch.tensor(observations.position_id).clone()
         
         # For now, we use states given by the path encoder and positions mostly for debugging
         states_so_far.append(states)
@@ -1022,8 +1020,6 @@ def rollout(
         ########################################
         if dev_mode:
             eval_metrics["sampled_actions"].append(sampled_actions.detach().cpu())
-            eval_metrics["visited_embeddings"].append(visited_embeddings.detach().cpu())
-            eval_metrics["position_ids"].append(position_ids.detach().cpu())
             eval_metrics["kge_cur_pos"].append(observations.kge_cur_pos.detach().cpu())
             eval_metrics["kge_prev_pos"].append(observations.kge_prev_pos.detach().cpu())
             eval_metrics["kge_action"].append(observations.kge_action.detach().cpu())

--- a/multihopkg/environments.py
+++ b/multihopkg/environments.py
@@ -9,8 +9,6 @@ import torch
 
 @dataclass
 class Observation:
-    position: np.ndarray # Debugging
-    position_id: np.ndarray # Debuggin
     state: torch.Tensor # Part of computation Graph
     kge_cur_pos: torch.Tensor # KG embedding vector of the current position
     kge_prev_pos: torch.Tensor # KG embedding vector of the previous position

--- a/multihopkg/rl/graph_search/pn.py
+++ b/multihopkg/rl/graph_search/pn.py
@@ -672,10 +672,6 @@ class ITLGraphEnvironment(Environment, nn.Module):
         #                     min=self.knowledge_graph.sun_model.entity_embedding.min(),
         #                     max=self.knowledge_graph.sun_model.entity_embedding.max()) 
 
-        matched_entity_embeddings, corresponding_ent_idxs = self.ann_index_manager_ent.search(
-            self.current_position.detach(), topk=1
-        )
-
         ########################################
         # Projections
         ########################################
@@ -700,8 +696,6 @@ class ITLGraphEnvironment(Environment, nn.Module):
 
         # Corresponding indices is a list of indices of the matched embeddings (batch_size, topk=1)
         observation = Observation(
-            position=matched_entity_embeddings,
-            position_id=corresponding_ent_idxs,
             state=projected_state,
             kge_cur_pos=self.current_position, #.detach(), # TODO: Check if we need to detach this for reward calculation
             kge_prev_pos=detached_curpos,
@@ -816,10 +810,8 @@ class ITLGraphEnvironment(Environment, nn.Module):
         # projected_state = projected_concat
 
         observation = Observation(
-            position=self.current_position.detach().cpu().numpy(),
-            position_id=np.zeros((self.current_position.shape[0])),
             state=projected_state,
-            kge_cur_pos=self.current_position, #.detach(),
+            kge_cur_pos=self.current_position,
             kge_prev_pos=torch.zeros_like(self.current_position.detach()),
             kge_action=torch.zeros(self.action_dim),
         )

--- a/multihopkg/utils_debug/dump_evals.py
+++ b/multihopkg/utils_debug/dump_evals.py
@@ -43,7 +43,6 @@ def dump_evaluation_metrics(
     # TODO: Here we are missing dic keys: sampled_actions, position_ids, hunch_llm_final_guesses
     assertions = [
         "sampled_actions" in evaluation_metrics_dictionary,
-        "position_ids" in evaluation_metrics_dictionary,
         "reference_questions" in evaluation_metrics_dictionary,
         "true_answer" in evaluation_metrics_dictionary,
         "relevant_entities" in evaluation_metrics_dictionary,
@@ -214,6 +213,7 @@ def dump_evaluation_metrics(
             position_distance_avg = []
             position_distance_ans = []
             closest_emb_distance = []
+            position_avg = []
             
             for i0 in range(kge_cur_pos.shape[0]):
                 diff = kg_ent_distance_func(kge_cur_pos[i0], kge_prev_pos[i0])
@@ -225,6 +225,8 @@ def dump_evaluation_metrics(
 
                 diff_closest = kg_ent_distance_func(kge_cur_pos[i0], entity_emb[i0])
                 diff_closest = conversion_constant*diff_closest.mean().item()
+                
+                position_avg.append(f"{conversion_constant*kge_cur_pos[i0].mean().item():.2e}")
 
                 position_distance.append(f"{diff_total:.2e}")
                 position_distance_avg.append(f"{diff_avg:.2e}")
@@ -237,6 +239,8 @@ def dump_evaluation_metrics(
             log_file.write(f"Avg. {translation_type} between KGE Positions {unit_type}:\n {position_distance_avg} \n")
             log_file.write(f"Avg. {translation_type} Debt between Current KGE and Answer {unit_type}:\n {position_distance_ans} \n")
             log_file.write(f"Avg. {translation_type} Debt between Current KGE Pos. and Closest Entity {unit_type}:\n {closest_emb_distance} \n")
+            log_file.write(f"Current Position (Mean):\n {position_avg} \n")
+            log_file.write(f"Answer Position (Mean):\n {conversion_constant*ans_emb.mean().item():.2e} \n")
 
             wandb_positions.append(" --> ".join(position_distance))
 

--- a/nav_training.py
+++ b/nav_training.py
@@ -164,7 +164,7 @@ def rollout(
         relevant_ent = relevant_entities
     )
 
-    cur_position, cur_state = observations.position, observations.state
+    cur_state = observations.state
     # Should be of shape (batch_size, 1, hidden_dim)
 
     # pn.initialize_path(kg) # TOREM: Unecessasry to ask pn to form it for us.
@@ -180,8 +180,6 @@ def rollout(
         # Ah ssampled_actions are the ones that have to go against the knowlde garph.
 
         states = observations.state
-        visited_embeddings = observations.position.clone() if isinstance(observations.position, torch.Tensor) else torch.tensor(observations.position).clone()
-        position_ids = observations.position_id.clone() if isinstance(observations.position_id, torch.Tensor) else torch.tensor(observations.position_id).clone()
         
         # For now, we use states given by the path encoder and positions mostly for debugging
         states_so_far.append(states)
@@ -214,8 +212,6 @@ def rollout(
         ########################################
         if dev_mode:
             eval_metrics["sampled_actions"].append(sampled_actions.detach().cpu())
-            eval_metrics["visited_embeddings"].append(visited_embeddings.detach().cpu())
-            eval_metrics["position_ids"].append(position_ids.detach().cpu())
             eval_metrics["kge_cur_pos"].append(observations.kge_cur_pos.detach().cpu())
             eval_metrics["kge_prev_pos"].append(observations.kge_prev_pos.detach().cpu())
             eval_metrics["kge_action"].append(observations.kge_action.detach().cpu())

--- a/nav_training.py
+++ b/nav_training.py
@@ -449,7 +449,6 @@ def evaluate_training(
     question_tokenizer: PreTrainedTokenizer,
     wandb_on: bool,
     iteration: int,
-    answer_id: List[int] = None,
 ):
     """
     Evaluates the performance of the navigation agent on the development set.
@@ -558,6 +557,8 @@ def evaluate_training(
 
             # eval_extras has variables that we need
             just_dump_it_here = "./logs/nav_evaluation_dumps.log"
+
+            answer_id = current_evaluations["true_answer_id"].tolist()
 
             answer_kge_tensor = get_embeddings_from_indices(
                 env.knowledge_graph.entity_embedding,
@@ -748,7 +749,6 @@ def train_nav_multihopkg(
                     question_tokenizer,
                     wandb_on,
                     iteration = epoch_id * (len(train_data) // batch_size // mbatches_b4_eval) + (batch_count // mbatches_b4_eval),
-                    answer_id=mini_batch["Answer-Entity"].tolist(),  # Extract answer_id from mini_batch
                 )
 
             ########################################


### PR DESCRIPTION
- Removed Position and Position ID from Observation, from PN (as it slows
down computation) and dump_eval, as it is redundant computation that
already takes place in dump_eval and significantly slows down the
training for rotational models due to sub-optimal implementation of
ANN_Index_Man_pRotate.

- The answer embedding selected for dump evaluation was constantly
changing due to the answer id belonging to a different answer each time
(random). As such, the distance comparison towards the answer was not
correct (only in the dump).